### PR TITLE
fix: reuse listen ports after Ctrl+C shutdown

### DIFF
--- a/master.py
+++ b/master.py
@@ -57,6 +57,9 @@ def close_listening_socket_at_exit():
 
 
 def try_bind_port(sock, addr):
+    if hasattr(socket, "SO_REUSEADDR"):
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+
     while True:
         try:
             sock.bind(addr)
@@ -149,8 +152,12 @@ class Master(object):
         self.thread_pool["assign_slaver_daemon"].start()
         self.thread_pool["socket_bridge"] = self.socket_bridge.start_as_daemon()
 
-        while True:
-            time.sleep(10)
+        try:
+            while True:
+                time.sleep(10)
+        except KeyboardInterrupt:
+            log.info("KeyboardInterrupt received, shutting down listening sockets")
+            close_listening_socket_at_exit()
 
     def _make_ssl_context(self):
         if ssl is None:


### PR DESCRIPTION
  ## What

  Fix `master.py` so it can restart immediately after `Ctrl+C` without getting stuck in the bind retry loop with:

  `[Errno 98] Address already in use`

  ## Why

  When the master process is interrupted, the listening sockets may not be reusable right away. That makes quick restarts painful and causes repeated `unable to bind` log messages even though the previous process has already exited.

  ## Changes

  - set `SO_REUSEADDR` on master listening sockets before `bind()`
  - catch `KeyboardInterrupt` in `serve_forever()`
  - close listening sockets explicitly during shutdown

  ## Result

  Restarting `master.py` on the same `-m` and `-c` ports works immediately after `Ctrl+C`, instead of waiting for the OS to release the old listener state.

  ## Verification

  - ran `python3 -m py_compile master.py slaver.py common_func.py`
  - started `master.py` on local test ports
  - sent `Ctrl+C`
  - restarted immediately on the same ports successfully